### PR TITLE
Get the roles right...

### DIFF
--- a/lib/stateAttr.js
+++ b/lib/stateAttr.js
@@ -34,7 +34,7 @@ const state_attrb = {
 	},
 	'on': {
 		name: 'On / Off',
-		role: 'switch',
+		role: 'switch.light',
 		write: true,
 	},
 	'bri': {

--- a/lib/stateAttr.js
+++ b/lib/stateAttr.js
@@ -39,7 +39,7 @@ const state_attrb = {
 	},
 	'bri': {
 		name: 'Brightness of the light',
-		role: 'value.brightness',
+		role: 'level.brightness',
 		min: 0,
 		max: 255,
 		write: true,


### PR DESCRIPTION
WLED Adapter uses some self defined roles and uses some other roles wrongly. For reference of roles, see here: https://www.iobroker.net/#en/documentation/dev/stateroles.md

Some roles that I did already change, because those changes where easy:
1. `bri` now has the role `level.brightness`. **value** is **Number, read only**. But the state has write flag set to true. So my assumption is that the state is used to control brightness and not only display values reported by the device (which  the value role suggests).
2. `on` now has the role `switch.light` to make detection more robust.

With those two changes a wled can already be detected as dimmable lamp (I had some issues with the mix of channels and states in my tests, but that might be a local issue or is a type-detector issue).

I did not yet understand how to control color.

This PR fixes two point in issue #428. For more fixes, more input is needed (especially the color stuff... what about color temperature?)
